### PR TITLE
keydown event を listen し 1秒以上入力がなければ、URL をクリッカブルにする

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,23 @@ $(document).on("keydown", function (e) {
   }
 })
 
+const waitAndExecute = (stack, callback) => {
+  stack.forEach(e => {
+    clearTimeout(e)
+    stack.shift()
+  })
+
+  const eventId = setTimeout(callback, 1000)
+  stack.push(eventId)
+}
+
+const stack = []
+$(document).keydown(_ => {
+  waitAndExecute(stack, () => {
+    $(".cm-link").on("click", e => window.open(e.target.innerHTML))
+  })
+})
+
 $("#createNewTabBtn").on("click", createNewTab)
 $("#deleteActiveTabBtn").on("click", deleteActiveTab)
 


### PR DESCRIPTION
## Issues

- 🍆 

## Why

`simplemde` では、URL のような文字列を検知して、アンダーラインをつけてくれる（class="cm-link" をつける）機能があるが、それをclick してもそのページに飛ぶことはなかった。

## What

keydown event を listen し 1秒以上入力がなければ、URL をクリッカブルにするようにした。