### PR TITLE
EditableTab の div の親 Node の div を導入することにより、Tab 操作をリファクタ

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
       <button id="deleteActiveTabBtn" class="OperationBtn">
         Delete
       </button>
+      <div id="tab-list" style="display: inline-block; vertical-align: top;"></div>
     </div>
   </div>
   <div style="margin: auto; height: 90%; max-width: 800px;">

--- a/index.js
+++ b/index.js
@@ -44,19 +44,20 @@ $(document).on("keydown", function (e) {
     return false
   }
 
+  const tabs = document.getElementById('tab-list').children
   const active = document.getElementsByClassName("ActiveTab")[0]
-  const idx = Array.prototype.indexOf.call(active.parentNode.children, active)
+  const idx = Array.prototype.indexOf.call(tabs, active)
 
   if (e.metaKey && e.which === 37) {
-    if (idx === 2) return
-    focusTab(active.parentNode.children[idx - 1])
+    if (idx === 0) return
+    focusTab(tabs[idx - 1])
     e.preventDefault()
     return false
   }
 
   if (e.metaKey && e.which === 39) {
-    if (active.parentNode.children.length - 1 === idx) return
-    focusTab(active.parentNode.children[idx + 1])
+    if (tabs.length - 1 === idx) return
+    focusTab(tabs[idx + 1])
     e.preventDefault()
     return false
   }
@@ -101,7 +102,7 @@ function createNewTabElem(content = null, active = false) {
   newTabElem.onclick = function () {
     focusTab(this)
   }
-  $("#button-list").append(newTabElem)
+  $("#tab-list").append(newTabElem)
 }
 
 function loadTabFromStore(content, active = false) {
@@ -112,7 +113,7 @@ function loadTabFromStore(content, active = false) {
 }
 
 function activateLastTab() {
-  const tabs = document.getElementById("button-list").childNodes
+  const tabs = document.getElementById("tab-list").childNodes
   const lastTab = tabs[tabs.length - 1]
   lastTab.className += " ActiveTab"
   const savedTab = contents.find((content) => content.id === lastTab.id)
@@ -125,7 +126,7 @@ function activateLastTab() {
 }
 
 function deactivateAllTabs() {
-  const tabs = document.getElementById("button-list").childNodes
+  const tabs = document.getElementById("tab-list").childNodes
   tabs.forEach(function (tab) {
     if (tab.classList !== undefined) {
       tab.classList.remove("ActiveTab")

--- a/index.js
+++ b/index.js
@@ -26,6 +26,17 @@ window.addEventListener("unload", function () {
   saveActiveTab()
 })
 
+const waitAndExecute = (stack, callback) => {
+  stack.forEach(e => {
+    clearTimeout(e)
+    stack.shift()
+  })
+
+  const eventId = setTimeout(callback, 1000)
+  stack.push(eventId)
+}
+
+const stack = []
 $(document).on("keydown", function (e) {
   if (e.metaKey && e.which === 83) {
     saveActiveTab()
@@ -49,20 +60,7 @@ $(document).on("keydown", function (e) {
     e.preventDefault()
     return false
   }
-})
 
-const waitAndExecute = (stack, callback) => {
-  stack.forEach(e => {
-    clearTimeout(e)
-    stack.shift()
-  })
-
-  const eventId = setTimeout(callback, 1000)
-  stack.push(eventId)
-}
-
-const stack = []
-$(document).keydown(_ => {
   waitAndExecute(stack, () => {
     saveActiveTab()
     $(".cm-link").on("click", e => window.open(e.target.innerHTML))


### PR DESCRIPTION
## Issues

- なし

## Why

EditableTab の div の親 Node が create や delete の button まで含んでしまっており、tab 操作の部分が読みづらかったため修正した

## What

- 本PRとは直接関係ないが、散らばっていた keydown event のコードを統一した https://github.com/konoyono/Remarque/commit/1944d30ceebe7e0e410b148bf58c13e97a9addae
- tab-list という ID で EditableTab の親 Nodeを作成し、既存コードをリファクタした https://github.com/konoyono/Remarque/commit/5833a85966879da0c45e222cee4e02e771c60358