### PR TITLE
タブが変わるときなど、中身を入れ替えるときにSimpleMDE を作り直すよう修正した

### DIFF
--- a/editor.js
+++ b/editor.js
@@ -1,0 +1,23 @@
+const editor = {
+  simplemde: {},
+  renew: (content = '') => {
+    const editorContainer = $("#editor-container")
+    editorContainer.empty()
+    editorContainer.append('<textarea id="editor"></textarea>')
+    this.simplemde = new SimpleMDE({
+      element: document.getElementById("editor"),
+      toolbar: [],
+      spellChecker: false,
+      status: false,
+      indentWithTabs: false,
+      tabSize: 2,
+    })
+    const codemirror = $('textarea[id="editor"]').nextAll(".CodeMirror")[0]
+    .CodeMirror
+      codemirror.getDoc().setValue(content)
+  },
+  value: () => {
+    return simplemde.value()
+  }
+}
+

--- a/index.html
+++ b/index.html
@@ -18,5 +18,6 @@
 
   <script src="jquery.min.js"></script>
   <script src="simplemde.min.js"></script>
+  <script src="editor.js"></script>
   <script src="index.js"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -14,9 +14,7 @@
       </button>
     </div>
   </div>
-  <div style="margin: auto; height: 90%; max-width: 800px;">
-    <textarea id="editor"></textarea>
-  </div>
+  <div id="editor-container" style="margin: auto; height: 90%; max-width: 800px;"></div>
 
   <script src="jquery.min.js"></script>
   <script src="simplemde.min.js"></script>

--- a/index.js
+++ b/index.js
@@ -1,13 +1,19 @@
-const simplemde = new SimpleMDE({
-  element: document.getElementById("editor"),
-  toolbar: [],
-  spellChecker: false,
-  status: false,
-  indentWithTabs: false,
-  tabSize: 2,
-})
+const renewSimplemde = () => {
+  const editorContainer = $("#editor-container")
+  editorContainer.empty()
+  editorContainer.append('<textarea id="editor"></textarea>')
+  return new SimpleMDE({
+    element: document.getElementById("editor"),
+    toolbar: [],
+    spellChecker: false,
+    status: false,
+    indentWithTabs: false,
+    tabSize: 2,
+  })
+}
 
 let contents
+let simplemde = renewSimplemde()
 
 chrome.storage.local.get({ storedContents: [], activeTabId: "" }, function (
   items
@@ -171,6 +177,7 @@ function deleteActiveTab() {
 }
 
 function loadTextarea(content) {
+  simplemde = renewSimplemde()
   const codemirror = $('textarea[id="editor"]').nextAll(".CodeMirror")[0]
     .CodeMirror
   codemirror.getDoc().setValue(content)

--- a/index.js
+++ b/index.js
@@ -86,7 +86,6 @@ function createNewTab() {
   saveActiveTab()
   deactivateAllTabs()
   createNewTabElem(null, true)
-  flushTextarea()
 }
 
 function createNewTabElem(content = null, active = false) {
@@ -171,7 +170,6 @@ function deleteActiveTab() {
   if (active === undefined) return
   contents = contents.filter((content) => content.id !== active.id)
   active.remove()
-  flushTextarea()
   chrome.storage.local.set({ storedContents: contents, activeTabId: active.id })
   activateLastTab()
 }
@@ -185,12 +183,6 @@ function loadTextarea(content) {
   $(".cm-link").on("click", function (e) {
     window.open(e.target.innerHTML)
   })
-}
-
-function flushTextarea() {
-  const codemirror = $('textarea[id="editor"]').nextAll(".CodeMirror")[0]
-    .CodeMirror
-  codemirror.getDoc().setValue("")
 }
 
 function countTabs() {

--- a/index.js
+++ b/index.js
@@ -1,19 +1,4 @@
-const renewSimplemde = () => {
-  const editorContainer = $("#editor-container")
-  editorContainer.empty()
-  editorContainer.append('<textarea id="editor"></textarea>')
-  return new SimpleMDE({
-    element: document.getElementById("editor"),
-    toolbar: [],
-    spellChecker: false,
-    status: false,
-    indentWithTabs: false,
-    tabSize: 2,
-  })
-}
-
 let contents
-let simplemde = renewSimplemde()
 
 chrome.storage.local.get({ storedContents: [], activeTabId: "" }, function (
   items
@@ -85,6 +70,7 @@ function createNewTab() {
   }
   saveActiveTab()
   deactivateAllTabs()
+  editor.renew()
   createNewTabElem(null, true)
 }
 
@@ -156,7 +142,7 @@ function saveActiveTab() {
   const json = {
     id: active.id,
     title: active.innerHTML,
-    content: simplemde.value(),
+    content: editor.value(),
   }
   const idx = contents.findIndex((content) => content.id === json.id)
   idx === -1 ? contents.push(json) : (contents[idx] = json)
@@ -175,10 +161,7 @@ function deleteActiveTab() {
 }
 
 function loadTextarea(content) {
-  simplemde = renewSimplemde()
-  const codemirror = $('textarea[id="editor"]').nextAll(".CodeMirror")[0]
-    .CodeMirror
-  codemirror.getDoc().setValue(content)
+  editor.renew(content)
 
   $(".cm-link").on("click", function (e) {
     window.open(e.target.innerHTML)


### PR DESCRIPTION
## Issues

https://github.com/konoyono/Remarque/issues/8

## Why

simplemde のインスタンスを保持していると、 JS による上書きも Cmd + z で戻してしまうため、
タブ移動前の違うタブの情報が現れてしまう。

## What

- タブが変わるときなど、中身を入れ替えるときにSimpleMDE を作り直すよう修正した
- simplemde の状態を 扱う editor オブジェクトを実装し、別 JS ファイルとして読み込むようにした

## Others

この対応をしたあとにもわかっている問題として、

> JS による上書きも Cmd + z で戻してしまう

ため、タブを開いた直後に Cmd + z すると、まっさらな（simplemde を立ち上げた直後のような）エディタになります。