### PR TITLE
不要なflushTextarea() 関数を削除

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,7 +79,6 @@ function createNewTab() {
   saveActiveTab()
   deactivateAllTabs()
   createNewTabElem(null, true)
-  flushTextarea()
 }
 
 function createNewTabElem(content = null, active = false) {
@@ -164,7 +163,6 @@ function deleteActiveTab() {
   if (active === undefined) return
   contents = contents.filter((content) => content.id !== active.id)
   active.remove()
-  flushTextarea()
   chrome.storage.local.set({ storedContents: contents, activeTabId: active.id })
   activateLastTab()
 }
@@ -177,12 +175,6 @@ function loadTextarea(content) {
   $(".cm-link").on("click", function (e) {
     window.open(e.target.innerHTML)
   })
-}
-
-function flushTextarea() {
-  const codemirror = $('textarea[id="editor"]').nextAll(".CodeMirror")[0]
-    .CodeMirror
-  codemirror.getDoc().setValue("")
 }
 
 function countTabs() {


### PR DESCRIPTION
## Issues

- なし

## Details

タブを移動したり新しいタブを作成する際に Simplemde のインスタンスを再作成するよう変更したことにより、 Simplemde の テキストを空にする flushTextarea() 関数を呼ぶ必要がなくなった。
関数と呼び出し箇所をすべて削除した。

```
$ git grep flushTextarea | wc -l
       0
```

