### PR TITLE
タブ切り替え直後に Undo history を削除

### DIFF
--- a/editor.js
+++ b/editor.js
@@ -1,6 +1,6 @@
 const editor = {
   simplemde: {},
-  renew: (content = '') => {
+  renew: (content = "") => {
     const editorContainer = $("#editor-container")
     editorContainer.empty()
     editorContainer.append('<textarea id="editor"></textarea>')
@@ -13,11 +13,11 @@ const editor = {
       tabSize: 4,
     })
     const codemirror = $('textarea[id="editor"]').nextAll(".CodeMirror")[0]
-    .CodeMirror
-      codemirror.getDoc().setValue(content)
+      .CodeMirror
+    codemirror.getDoc().setValue(content)
+    codemirror.clearHistory()
   },
   value: () => {
     return simplemde.value()
-  }
+  },
 }
-


### PR DESCRIPTION
https://sumiretool.net/article/d/web_app_tips/codemirror

#8 の残タスク。タブ切り替え直後に Cmd + z で中身が消滅する問題に対応。