### PR TITLE
使用していないショートカットキー削除

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,24 +37,6 @@ $(document).on("keydown", function (e) {
     return false
   }
 
-  const tabs = document.getElementById("tab-list").children
-  const active = document.getElementsByClassName("ActiveTab")[0]
-  const idx = Array.prototype.indexOf.call(tabs, active)
-
-  if (e.ctrlKey && e.which === 37) {
-    if (idx === 0) return
-    focusTab(tabs[idx - 1])
-    e.preventDefault()
-    return false
-  }
-
-  if (e.ctrlKey && e.which === 39) {
-    if (tabs.length - 1 === idx) return
-    focusTab(tabs[idx + 1])
-    e.preventDefault()
-    return false
-  }
-
   waitAndExecute(stack, () => {
     saveActiveTab()
     $(".cm-link").on("click", (e) => window.open(e.target.innerHTML))

--- a/index.js
+++ b/index.js
@@ -32,7 +32,6 @@ const waitAndExecute = (stack, callback) => {
 const stack = []
 $(document).on("keydown", function (e) {
   if (e.metaKey && e.which === 83) {
-    saveActiveTab()
     e.preventDefault()
     return false
   }


### PR DESCRIPTION
- Ctrl + 左右キーでタブ移動、作ったものの全然つかってなかった
- Cmd + s で保存も実際は効かなくてもいいので、OSの保存ダイアログを出すのだけ抑止する