### PR TITLE
chrome.storage.local.set している箇所を saveActiveTab に集約する

### DIFF
--- a/index.js
+++ b/index.js
@@ -168,6 +168,8 @@ function deleteActiveTab() {
   if (active === undefined) return
   contents = contents.filter((content) => content.id !== active.id)
   active.remove()
+  
+  // Delete ボタン押下されたときは右端のタブをアクティベートする
   const tabs = document.getElementById("tab-list").childNodes
   focusTab(tabs[tabs.length - 1])
 }

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ const waitAndExecute = (stack, callback) => {
     stack.shift()
   })
 
-  const eventId = setTimeout(callback, 1000)
+  const eventId = setTimeout(callback, 100)
   stack.push(eventId)
 }
 

--- a/index.js
+++ b/index.js
@@ -140,14 +140,8 @@ function focusTab(tab) {
   saveActiveTab()
   deactivateAllTabs()
   tab.className += " ActiveTab"
-  const savedTab = contents.find((content) => content.id === tab.id)
-  const content = savedTab === undefined ? "" : savedTab.content
-  loadTextarea(content)
-  chrome.storage.local.set({
-    storedContents: contents,
-    activeTabId: tab.id,
-    changeWindowId: window.id,
-  })
+  const focused = contents.find((content) => content.id === tab.id)
+  loadTextarea(focused.content)
 }
 
 function saveActiveTab() {

--- a/index.js
+++ b/index.js
@@ -127,20 +127,6 @@ function loadTabFromStore(content, active = false) {
   }
 }
 
-function activateLastTab() {
-  const tabs = document.getElementById("tab-list").childNodes
-  const lastTab = tabs[tabs.length - 1]
-  lastTab.className += " ActiveTab"
-  const savedTab = contents.find((content) => content.id === lastTab.id)
-  const content = savedTab === undefined ? "" : savedTab.content
-  loadTextarea(content)
-  chrome.storage.local.set({
-    storedContents: contents,
-    activeTabId: lastTab.id,
-    changeWindowId: window.id,
-  })
-}
-
 function deactivateAllTabs() {
   const tabs = document.getElementById("tab-list").childNodes
   tabs.forEach(function (tab) {
@@ -188,12 +174,8 @@ function deleteActiveTab() {
   if (active === undefined) return
   contents = contents.filter((content) => content.id !== active.id)
   active.remove()
-  chrome.storage.local.set({
-    storedContents: contents,
-    activeTabId: active.id,
-    changeWindowId: window.id,
-  })
-  activateLastTab()
+  const tabs = document.getElementById("tab-list").childNodes
+  focusTab(tabs[tabs.length - 1])
 }
 
 function loadTextarea(content) {


### PR DESCRIPTION
- ActivateLastTab は FocusTab に LastTab を渡すことで代用可能だったので、削除

<br>

- FocusTab のなかで SaveActiveTab が呼ばれているため、FocusTab での storage.local.set は不要だった
   - ただしそうすると syncLatestWindow が発火するまでに setTimeout の値だけ待つ必要が生じる。
Remarque のタブを切り替えたあとにブラウザのタブを切り替えて別の Remarque を参照すると、
1000 msec 後に Remarque のタブ切り替えが反映されるようになってしまった（ややこしい）
     - これに伴い、姑息対応として setTimeout を 100 msec に短縮