### PR TITLE
activeTabId 自体を削除し、各 content に active かそうでないか持たせる

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ chrome.storage.local.get(
         loadTabFromStore(content, content.id === items.activeTabId)
       })
     } else {
-      createNewTab()
+      initialize()
     }
   }
 )
@@ -80,10 +80,15 @@ function syncLatestWindow() {
           loadTabFromStore(content, content.id === items.activeTabId)
         })
       } else {
-        createNewTab()
+        initialize()
       }
     }
   )
+}
+
+function initialize() {
+  editor.renew()
+  createBlankTab()
 }
 
 function createNewTab() {

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ const waitAndExecute = (stack, callback) => {
     stack.shift()
   })
 
-  const eventId = setTimeout(callback, 1000)
+  const eventId = setTimeout(callback, 100)
   stack.push(eventId)
 }
 

--- a/index.js
+++ b/index.js
@@ -140,14 +140,8 @@ function focusTab(tab) {
   saveActiveTab()
   deactivateAllTabs()
   tab.className += " ActiveTab"
-  const savedTab = contents.find((content) => content.id === tab.id)
-  const content = savedTab === undefined ? "" : savedTab.content
-  loadTextarea(content)
-  chrome.storage.local.set({
-    storedContents: contents,
-    activeTabId: tab.id,
-    changeWindowId: window.id,
-  })
+  const focused = contents.find((content) => content.id === tab.id)
+  loadTextarea(focused.content)
 }
 
 function saveActiveTab() {

--- a/index.js
+++ b/index.js
@@ -137,7 +137,7 @@ function createTabFromStore(content) {
 }
 
 function loadTabFromStore(content, active = false) {
-  createTabFromStore(content, active)
+  createTabFromStore(content)
   if (active) {
     loadTextarea(content.content)
   }

--- a/index.js
+++ b/index.js
@@ -141,7 +141,10 @@ function focusTab(tab) {
   deactivateAllTabs()
   tab.className += " ActiveTab"
   const focused = contents.find((content) => content.id === tab.id)
-  loadTextarea(focused.content)
+  editor.renew(focused.content)
+  
+  // http スキームのリンクを clickable にする
+  $(".cm-link").on("click", (e) => window.open(e.target.innerHTML))
 }
 
 function saveActiveTab() {
@@ -170,14 +173,6 @@ function deleteActiveTab() {
   active.remove()
   const tabs = document.getElementById("tab-list").childNodes
   focusTab(tabs[tabs.length - 1])
-}
-
-function loadTextarea(content) {
-  editor.renew(content)
-
-  $(".cm-link").on("click", function (e) {
-    window.open(e.target.innerHTML)
-  })
 }
 
 function countTabs() {

--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ function syncLatestWindow() {
 
 function initialize() {
   editor.renew()
-  createBlankTab()
+  focusTab(createBlankTab())
 }
 
 function createNewTab() {
@@ -97,14 +97,14 @@ function createNewTab() {
     return
   }
   saveActiveTab()
-  deactivateAllTabs()
   editor.renew()
-  createBlankTab()
+  focusTab(createBlankTab())
 }
 
 function createNewTabElem() {
   const newTabElem = document.createElement("div")
   newTabElem.contentEditable = true
+  newTabElem.className = "EditableTab"
   newTabElem.addEventListener("keydown", function (e) {
     if (e.keyCode === 13) {
       e.preventDefault()
@@ -119,21 +119,21 @@ function createNewTabElem() {
 }
 
 function createBlankTab() {
-  const elem = createNewTabElem()
-  elem.id = idGenerator()
-  elem.innerHTML = "New Tab"
-  elem.className = "EditableTab ActiveTab"
+  const tab = createNewTabElem()
+  tab.id = idGenerator()
+  tab.innerHTML = "New Tab"
   
-  $("#tab-list").append(elem)
+  $("#tab-list").append(tab)
+  return tab
 }
 
-function createTabFromStore(content, active) {
-  const elem = createNewTabElem()
-  elem.id = content.id
-  elem.innerHTML = content.title
-  elem.className = active ? "EditableTab ActiveTab" : "EditableTab"
+function createTabFromStore(content) {
+  const tab = createNewTabElem()
+  tab.id = content.id
+  tab.innerHTML = content.title
   
-  $("#tab-list").append(elem)
+  $("#tab-list").append(tab)
+  return tab
 }
 
 function loadTabFromStore(content, active = false) {

--- a/index.js
+++ b/index.js
@@ -127,20 +127,6 @@ function loadTabFromStore(content, active = false) {
   }
 }
 
-function activateLastTab() {
-  const tabs = document.getElementById("tab-list").childNodes
-  const lastTab = tabs[tabs.length - 1]
-  lastTab.className += " ActiveTab"
-  const savedTab = contents.find((content) => content.id === lastTab.id)
-  const content = savedTab === undefined ? "" : savedTab.content
-  loadTextarea(content)
-  chrome.storage.local.set({
-    storedContents: contents,
-    activeTabId: lastTab.id,
-    changeWindowId: window.id,
-  })
-}
-
 function deactivateAllTabs() {
   const tabs = document.getElementById("tab-list").childNodes
   tabs.forEach(function (tab) {
@@ -188,12 +174,8 @@ function deleteActiveTab() {
   if (active === undefined) return
   contents = contents.filter((content) => content.id !== active.id)
   active.remove()
-  chrome.storage.local.set({
-    storedContents: contents,
-    activeTabId: active.id,
-    changeWindowId: window.id,
-  })
-  activateLastTab()
+  const tabs = document.getElementById("tab-list").childNodes
+  focusTab(tabs[tabs.length - 1])
 }
 
 function loadTextarea(content) {

--- a/index.js
+++ b/index.js
@@ -99,10 +99,10 @@ function createNewTab() {
   saveActiveTab()
   deactivateAllTabs()
   editor.renew()
-  createNewTabElem(null, true)
+  createBlankTab()
 }
 
-function createNewTabElem(content = null, active = false) {
+function createNewTabElem() {
   const newTabElem = document.createElement("div")
   newTabElem.contentEditable = true
   newTabElem.addEventListener("keydown", function (e) {
@@ -111,22 +111,33 @@ function createNewTabElem(content = null, active = false) {
       return false
     }
   })
-  if (content === null) {
-    newTabElem.id = idGenerator()
-    newTabElem.innerHTML = "New Tab"
-  } else {
-    newTabElem.id = content.id
-    newTabElem.innerHTML = content.title
-  }
-  newTabElem.className = active ? "EditableTab ActiveTab" : "EditableTab"
   newTabElem.onclick = function () {
     focusTab(this)
   }
-  $("#tab-list").append(newTabElem)
+  
+  return newTabElem
+}
+
+function createBlankTab() {
+  const elem = createNewTabElem()
+  elem.id = idGenerator()
+  elem.innerHTML = "New Tab"
+  elem.className = "EditableTab ActiveTab"
+  
+  $("#tab-list").append(elem)
+}
+
+function createTabFromStore(content, active) {
+  const elem = createNewTabElem()
+  elem.id = content.id
+  elem.innerHTML = content.title
+  elem.className = active ? "EditableTab ActiveTab" : "EditableTab"
+  
+  $("#tab-list").append(elem)
 }
 
 function loadTabFromStore(content, active = false) {
-  createNewTabElem(content, active)
+  createTabFromStore(content, active)
   if (active) {
     loadTextarea(content.content)
   }


### PR DESCRIPTION
activeTabId を content とは別に持って判定するのがわかりにくかったので、content に内包。

タブの状態を変更する箇所は集約できたものの、要素として画面に存在すると論理的な脈絡なく触られるがどうしたものか。
結局画面上に存在する tabs という表示要素と、そこに情報を入れるための contents というものを二重管理しているのがびみょい。